### PR TITLE
Revise cleanup scripts to not require cd

### DIFF
--- a/proj/cleanup.cmd
+++ b/proj/cleanup.cmd
@@ -1,13 +1,7 @@
-rem save working directory
-set orig_dir=%cd%
-rem get the directory containing this script
-set script_path=%~dp0
-set script_dir=%script_path:~0,-1%
-:: Do (Payload) within the script's directory
-cd %script_dir%
-
-rem go silent
 @echo off
+rem save current working directory
+pushd %~dp0
+
 rem delete all files from subfolders
 for /d /r %%i in (*) do del /f /q %%i\*
 rem delete all subfolders
@@ -29,4 +23,4 @@ rem unmark read-only
 attrib -R .\*
 
 rem restore original working directory
-cd %orig_dir%
+popd

--- a/proj/cleanup.cmd
+++ b/proj/cleanup.cmd
@@ -1,3 +1,12 @@
+rem save working directory
+set orig_dir=%cd%
+rem get the directory containing this script
+set script_path=%~dp0
+set script_dir=%script_path:~0,-1%
+:: Do (Payload) within the script's directory
+cd %script_dir%
+
+rem go silent
 @echo off
 rem delete all files from subfolders
 for /d /r %%i in (*) do del /f /q %%i\*
@@ -19,3 +28,5 @@ del /Q /A:-R .\*
 rem unmark read-only
 attrib -R .\*
 
+rem restore original working directory
+cd %orig_dir%

--- a/proj/cleanup.sh
+++ b/proj/cleanup.sh
@@ -5,10 +5,11 @@
 # this 'cleanup' file if needed:
 # chmod u+x cleanup.sh
 ###
+script_dir=$(dirname ${BASH_SOURCE[0]})
 # Remove directories/subdirectories
-find . -mindepth 1 -type d -exec rm -rf {} +
+find $script_dir -mindepth 1 -type d -exec rm -rf {} +
 # Remove any other files than:
-find . -type f ! -name 'cleanup.sh' \
+find $script_dir -type f ! -name 'cleanup.sh' \
                ! -name 'cleanup.cmd' \
                ! -name 'create_project.tcl' \
                ! -name '.gitignore' \


### PR DESCRIPTION
Detecting and either CDing into or acting only within the directory the cleanup scripts are placed in may help avoid these scripts removing other important parts of a filesystem.